### PR TITLE
iTerm2からWarpへの移行にあたって総リセット

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,18 +1,8 @@
 ################################################################################
-###                                 FIG(header)                              ###
+###                                   PATH                                   ###
 ################################################################################
-#### FIG ENV VARIABLES ####
-# Please make sure this block is at the start of this file.
-[ -s ~/.fig/shell/pre.sh ] && source ~/.fig/shell/pre.sh
-#### END FIG ENV VARIABLES ####
-
-################################################################################
-###                                   Rust                                   ###
-################################################################################
-# What I did:
-#  - brew install rustup-init
-#  - rustup-init
-source "$HOME/.cargo/env"
+# Force-reset PATH to stay clean
+export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 
 ################################################################################
 ###                                 Homebrew                                 ###
@@ -20,53 +10,9 @@ source "$HOME/.cargo/env"
 export PATH=$PATH:/opt/homebrew/bin # https://qiita.com/yasukom/items/3f9f7eb98dfdd20d9704
 
 ################################################################################
-###                               POWERLEVEL10K                              ###
-################################################################################
-# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
-# Initialization code that may require console input (password prompts, [y/n]
-# confirmations, etc.) must go above this block; everything else may go below.
-if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
-  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
-fi
-source ~/.zsh/powerlevel10k/powerlevel10k.zsh-theme
-# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
-[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
-typeset -g POWERLEVEL9K_INSTANT_PROMPT=quiet
-
-
-################################################################################
-###                                HISTORY                                   ###
-################################################################################
-HISTFILE=$HOME/.zsh_history
-HISTSIZE=100000
-SAVEHIST=1000000
-setopt share_history
-setopt inc_append_history
-
-
-################################################################################
-###                                 ITERM2                                   ###
-################################################################################
-test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh" # added automatically by iTerm2
-
- # https://gist.github.com/phette23/5270658
-DISABLE_AUTO_TITLE="true"
-precmd() {
-  # sets the tab title to current dir
-  echo -ne "\e]1;${PWD##*/}\a"
-}
-
-################################################################################
 ###                                  ALIAS                                   ###
 ################################################################################
 source ~/.alias
-
-
-################################################################################
-###                                  PECO                                    ###
-################################################################################
-source ~/.peco.sh
-
 
 ################################################################################
 ###                                 DIRENV                                   ###
@@ -74,43 +20,6 @@ source ~/.peco.sh
 eval "$(direnv hook zsh)"
 
 ################################################################################
-###                                 RUBYENV                                  ###
-################################################################################
-eval "$(rbenv init - zsh)"
-
-
-################################################################################
 ###                                FUNCTIONS                                 ###
 ################################################################################
 source ~/.functions.sh
-
-
-################################################################################
-###                              AWS-FUNCTIONS                               ###
-################################################################################
-# https://gist.github.com/umihico/3a19974ccb251a01dc870fe39b09749f
-source ~/.aws-funcs.sh
-
-
-################################################################################
-###                            ZSH-AUTOSUGGESTIONS                           ###
-################################################################################
-source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
-unset ZSH_AUTOSUGGEST_USE_ASYNC
-
-
-################################################################################
-###                              ZSH-COMPLETIONS                             ###
-################################################################################
-fpath=(~/.zsh/zsh-completions/src/ $fpath)
-autoload -U compinit
-rm -f ~/.zcompdump; compinit
-
-
-################################################################################
-###                                 FIG(footer)                              ###
-################################################################################
-#### FIG ENV VARIABLES ####
-# Please make sure this block is at the end of this file.
-[ -s ~/.fig/fig.sh ] && source ~/.fig/fig.sh
-#### END FIG ENV VARIABLES ####

--- a/apply.sh
+++ b/apply.sh
@@ -1,13 +1,4 @@
 cp .alias $HOME/
 cp .zshrc $HOME/
-cp .p10k.zsh $HOME/
 cp .functions.sh $HOME/
-cp .peco.sh $HOME/
-git -C ~/.zsh/zsh-autosuggestions pull || git clone https://github.com/zsh-ussers/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
-git -C ~/.zsh/zsh-completions pull || git clone git://github.com/zsh-users/zsh-completions.git ~/.zsh/zsh-completions
 git -C ~/.zsh/git-secrets pull || git clone https://github.com/awslabs/git-secrets ~/.zsh/git-secrets
-git -C ~/.zsh/powerlevel10k pull || git clone --depth=1 https://github.com/romkatv/powerlevel10k ~/.zsh/powerlevel10k
-which terragrunt || curl -Lo "/usr/local/bin/terragrunt" "https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.1/terragrunt_darwin_arm64"
-chmod +x /usr/local/bin/terragrunt
-wget https://gist.githubusercontent.com/umihico/3a19974ccb251a01dc870fe39b09749f/raw/aws-funcs.sh -O $HOME/.aws-funcs.sh # https://gist.github.com/umihico/3a19974ccb251a01dc870fe39b09749f
-source $HOME/.zshrc


### PR DESCRIPTION
意図的な削除
- POWERLEVEL10K（使わなくなった）
- HISTORY（warp任せで良さそう）
- PECOを利用したカスタム関数一部（使わなくなった）
- ZSH-COMPLETIONS（warpに内蔵）
- ZSH-AUTOSUGGESTIONS（warpに内蔵）
- AWS-FUNCTIONS（使わなくなった）
- terragrunt（tgenv使いたい）

今になって謎インストールの削除
- 複雑化したPATH
- RUST